### PR TITLE
only use asgiref.typing for typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "httpx>=0.27.0",
     "polars>=1.5.0",
     "granian>=1.5.2",
-    "asgiref>=3.8.1",
 ]
 
 [project.scripts]
@@ -20,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 dev-dependencies = [
+    "asgiref>=3.8.1",
     "ruff>=0.6.1",
     "pyright>=1.1.377",
 ]

--- a/src/demo/web.py
+++ b/src/demo/web.py
@@ -1,12 +1,15 @@
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPScope,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPScope,
+    )
 
 
 async def app(
-    scope: HTTPScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+    scope: "HTTPScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
 ) -> None:
     assert scope["type"] == "http"
 

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,6 @@ name = "demo"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "asgiref" },
     { name = "granian" },
     { name = "httpx" },
     { name = "polars" },
@@ -66,13 +65,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "asgiref" },
     { name = "pyright" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "asgiref", specifier = ">=3.8.1" },
     { name = "granian", specifier = ">=1.5.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "polars", specifier = ">=1.5.0" },
@@ -80,6 +79,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "asgiref", specifier = ">=3.8.1" },
     { name = "pyright", specifier = ">=1.1.377" },
     { name = "ruff", specifier = ">=0.6.1" },
 ]


### PR DESCRIPTION
make `asgiref` a dev dependency since we only need it for static type checking, and don't need it in the runtime docker image.

had to rewrite the type annotations as strings though.

we'll see how far this goes, since I might need the typing at runtime at some point.